### PR TITLE
fix(cli): keep pinned-channel integration discovery coherent

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -138,10 +138,10 @@ internal sealed class AddCommand : BaseCommand
             // the version. If there is more than one match then we prompt.
             var selectedNuGetPackage = filteredPackagesWithShortName.Count() switch
             {
-                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(effectiveAppHostProjectFile.Directory!, packagesWithShortName, integrationName, version, cancellationToken),
+                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(effectiveAppHostProjectFile.Directory!, packagesWithShortName, integrationName, version, configuredChannel, cancellationToken),
                 1 when filteredPackagesWithShortName.First().Package.Version == version
                     => filteredPackagesWithShortName.First(),
-                _ => await GetPackageByInteractiveFlow(effectiveAppHostProjectFile.Directory!, filteredPackagesWithShortName, version, cancellationToken)
+                _ => await GetPackageByInteractiveFlow(effectiveAppHostProjectFile.Directory!, filteredPackagesWithShortName, version, configuredChannel, cancellationToken)
             };
 
             // When installing from a PR channel, ensure the project has access to
@@ -262,7 +262,7 @@ internal sealed class AddCommand : BaseCommand
         return versions;
     }
 
-    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlow(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? preferredVersion, CancellationToken cancellationToken)
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlow(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? preferredVersion, string? configuredChannel, CancellationToken cancellationToken)
     {
         var distinctPackages = possiblePackages.DistinctBy(p => p.Package.Id);
 
@@ -316,11 +316,11 @@ internal sealed class AddCommand : BaseCommand
             return cliVersionPackage;
         }
 
-        // In non-interactive mode, prefer the implicit/default channel first to keep
-        // package selection aligned with the project's configured feeds. Then select
-        // the latest version within the chosen channel.
+        // A project-pinned channel wins for shared package IDs; otherwise keep the
+        // existing implicit/default preference for unpinned projects with hives.
         var orderedPackageVersions = packageVersions
-            .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
+            .OrderByDescending(p => IntegrationPackageSearchService.IsConfiguredChannel(p.Channel, configuredChannel))
+            .ThenByDescending(p => string.IsNullOrEmpty(configuredChannel) && p.Channel.Type is PackageChannelType.Implicit)
             .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer);
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
@@ -328,19 +328,19 @@ internal sealed class AddCommand : BaseCommand
         }
 
         // ... otherwise we had better prompt.
-        var version = await _prompter.PromptForIntegrationVersionAsync(orderedPackageVersions, cancellationToken);
+        var version = await _prompter.PromptForIntegrationVersionAsync(orderedPackageVersions, configuredChannel, cancellationToken);
 
         return version;
     }
 
-    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlowWithNoMatchesMessage(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? searchTerm, string? preferredVersion, CancellationToken cancellationToken)
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlowWithNoMatchesMessage(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? searchTerm, string? preferredVersion, string? configuredChannel, CancellationToken cancellationToken)
     {
         if (searchTerm is not null)
         {
             InteractionService.DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.NoPackagesMatchedSearchTerm, searchTerm));
         }
 
-        return await GetPackageByInteractiveFlow(workingDirectory, possiblePackages, preferredVersion, cancellationToken);
+        return await GetPackageByInteractiveFlow(workingDirectory, possiblePackages, preferredVersion, configuredChannel, cancellationToken);
     }
 
 }
@@ -348,12 +348,12 @@ internal sealed class AddCommand : BaseCommand
 internal interface IAddCommandPrompter
 {
     Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, CancellationToken cancellationToken);
-    Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationVersionAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, CancellationToken cancellationToken);
+    Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationVersionAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? configuredChannel, CancellationToken cancellationToken);
 }
 
 internal class AddCommandPrompter(IInteractionService interactionService) : IAddCommandPrompter
 {
-    public virtual async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationVersionAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)
+    public virtual async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationVersionAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? configuredChannel, CancellationToken cancellationToken)
     {
         var firstPackage = packages.First();
 
@@ -402,11 +402,12 @@ internal class AddCommandPrompter(IInteractionService interactionService) : IAdd
             .ToArray();
 
         var implicitGroup = byChannel.FirstOrDefault(g => g.Channel.Type is Packaging.PackageChannelType.Implicit);
+        var configuredGroup = byChannel.FirstOrDefault(g => IntegrationPackageSearchService.IsConfiguredChannel(g.Channel, configuredChannel));
         var explicitGroups = byChannel
             .Where(g => g.Channel.Type is Packaging.PackageChannelType.Explicit)
             .ToArray();
 
-        // If there are no explicit channels, automatically select from the implicit channel
+        // If there are no explicit channels, automatically select from the implicit channel.
         if (explicitGroups.Length == 0 && implicitGroup is not null)
         {
             return implicitGroup.HighestVersion;
@@ -415,25 +416,44 @@ internal class AddCommandPrompter(IInteractionService interactionService) : IAdd
         // Build the root menu: implicit channel packages directly, explicit channels as submenus
         var rootChoices = new List<(string Label, Func<CancellationToken, Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)>> Action)>();
 
-        if (implicitGroup is not null)
+        void AddRootChoice(PackageChannel channel, (string FriendlyName, NuGetPackage Package, PackageChannel Channel) item)
         {
-            var captured = implicitGroup.HighestVersion;
-            rootChoices.Add((
-                Label: FormatVersionLabel(captured),
-                Action: ct => Task.FromResult(captured)
-            ));
+            if (channel.Type is Packaging.PackageChannelType.Implicit)
+            {
+                rootChoices.Add((
+                    Label: FormatVersionLabel(item),
+                    Action: ct => Task.FromResult(item)
+                ));
+            }
+            else
+            {
+                rootChoices.Add((
+                    Label: channel.Name.EscapeMarkup(),
+                    Action: ct => PromptForChannelPackagesAsync(channel, new[] { item }, ct)
+                ));
+            }
+        }
+
+        if (configuredGroup is not null)
+        {
+            AddRootChoice(configuredGroup.Channel, configuredGroup.HighestVersion);
+        }
+
+        if (implicitGroup is not null && !IntegrationPackageSearchService.IsConfiguredChannel(implicitGroup.Channel, configuredChannel))
+        {
+            AddRootChoice(implicitGroup.Channel, implicitGroup.HighestVersion);
         }
 
         foreach (var channelGroup in explicitGroups)
         {
             var channel = channelGroup.Channel;
             var item = channelGroup.HighestVersion;
+            if (IntegrationPackageSearchService.IsConfiguredChannel(channel, configuredChannel))
+            {
+                continue;
+            }
 
-            rootChoices.Add((
-                Label: channel.Name.EscapeMarkup(),
-                // For explicit channels, we still show submenu but with only the highest version
-                Action: ct => PromptForChannelPackagesAsync(channel, new[] { item }, ct)
-            ));
+            AddRootChoice(channel, item);
         }
 
         // Fallback if no choices for some reason

--- a/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
+++ b/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
@@ -23,17 +23,16 @@ internal sealed class IntegrationPackageSearchService(
 
     public async Task<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>> GetIntegrationPackagesWithChannelsAsync(DirectoryInfo workingDirectory, string? configuredChannel, CancellationToken cancellationToken)
     {
-        var allChannels = await packagingService.GetChannelsAsync(cancellationToken, configuredChannel);
-
-        if (!string.IsNullOrEmpty(configuredChannel))
-        {
-            allChannels = allChannels.Where(c => string.Equals(c.Name, configuredChannel, StringComparison.OrdinalIgnoreCase));
-        }
+        var allChannels = (await packagingService.GetChannelsAsync(cancellationToken, configuredChannel)).ToArray();
 
         var hasHives = executionContext.GetHiveCount() > 0;
-        var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
-            ? allChannels
-            : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+        var channels = !string.IsNullOrEmpty(configuredChannel)
+            ? allChannels.Any(c => IsConfiguredChannel(c, configuredChannel))
+                ? allChannels.Where(c => c.Type is PackageChannelType.Implicit || IsConfiguredChannel(c, configuredChannel))
+                : []
+            : hasHives
+                ? allChannels
+                : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
 
         var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
         var packagesLock = new object();
@@ -82,14 +81,6 @@ internal sealed class IntegrationPackageSearchService(
 
     public (string? ConfiguredChannel, int? ExitCode) GetConfiguredChannel(FileInfo appHostProjectFile, IAppHostProject project)
     {
-        // For non-.NET projects, read the channel from the local Aspire configuration if available.
-        // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
-        // in aspire.config.json (or the legacy settings.json during migration).
-        if (project.LanguageId == KnownLanguageId.CSharp)
-        {
-            return (ConfiguredChannel: null, ExitCode: null);
-        }
-
         var appHostDirectory = appHostProjectFile.Directory!.FullName;
         var isProjectReferenceMode = project.IsUsingProjectReferences(appHostProjectFile);
         if (isProjectReferenceMode)
@@ -128,12 +119,19 @@ internal sealed class IntegrationPackageSearchService(
             .ThenByDescending(p => p.FriendlyName, new CommunityToolkitFirstComparer());
     }
 
-    public static (string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore) SelectPreferredIntegrationPackage(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> packages)
+    public static (string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore) SelectPreferredIntegrationPackage(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> packages, string? configuredChannel)
     {
         return packages
-            .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
+            .OrderByDescending(p => IsConfiguredChannel(p.Channel, configuredChannel))
+            .ThenByDescending(p => string.IsNullOrEmpty(configuredChannel) && p.Channel.Type is PackageChannelType.Implicit)
             .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer)
             .First();
+    }
+
+    public static bool IsConfiguredChannel(PackageChannel channel, string? configuredChannel)
+    {
+        return !string.IsNullOrEmpty(configuredChannel) &&
+            string.Equals(channel.Name, configuredChannel, StringComparison.OrdinalIgnoreCase);
     }
 
     private static double GetIntegrationSearchScore(string searchTerm, (string FriendlyName, NuGetPackage Package, PackageChannel Channel) package)

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -72,7 +72,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
                 .OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer())
                 .ToArray();
 
-            return CommandResult.FromExitCode(DisplayIntegrationResults(packagesWithShortName, searchTerm, format));
+            return CommandResult.FromExitCode(DisplayIntegrationResults(packagesWithShortName, searchTerm, format, configuredChannel));
         }
         catch (ProjectLocatorException ex)
         {
@@ -90,13 +90,13 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         }
     }
 
-    private int DisplayIntegrationResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, OutputFormat format)
+    private int DisplayIntegrationResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, OutputFormat format, string? configuredChannel)
     {
         var matches = (searchTerm is null
             ? packages.Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: 0.0))
             : IntegrationPackageSearchService.GetIntegrationSearchMatches(packages, searchTerm))
             .GroupBy(p => p.Package.Id)
-            .Select(IntegrationPackageSearchService.SelectPreferredIntegrationPackage);
+            .Select(p => IntegrationPackageSearchService.SelectPreferredIntegrationPackage(p, configuredChannel));
 
         var orderedMatches = searchTerm is null
             ? matches.OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer()).ThenBy(p => p.Package.Id, StringComparer.OrdinalIgnoreCase)

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Scaffolding;
@@ -70,7 +71,7 @@ internal sealed partial class CliTemplateFactory
                     if (isCsharp)
                     {
                         _logger.LogDebug("Using embedded C# empty AppHost template for '{OutputPath}'.", outputPath);
-                        await WriteCSharpEmptyAppHostAsync(inputs.Version, outputPath, projectName, useLocalhostTld, cancellationToken);
+                        await WriteCSharpEmptyAppHostAsync(inputs.Version, inputs.Channel, outputPath, projectName, useLocalhostTld, cancellationToken);
                     }
                     else
                     {
@@ -154,7 +155,7 @@ internal sealed partial class CliTemplateFactory
         }
     }
 
-    private async Task WriteCSharpEmptyAppHostAsync(string? templateVersion, string outputPath, string projectName, bool useLocalhostTld, CancellationToken cancellationToken)
+    private async Task WriteCSharpEmptyAppHostAsync(string? templateVersion, string? configuredChannel, string outputPath, string projectName, bool useLocalhostTld, CancellationToken cancellationToken)
     {
         var aspireVersion = string.IsNullOrWhiteSpace(templateVersion)
             ? VersionHelper.GetDefaultTemplateVersion()
@@ -166,5 +167,19 @@ internal sealed partial class CliTemplateFactory
 
         _logger.LogDebug("Writing C# empty AppHost template files to '{OutputPath}' with Aspire version '{AspireVersion}'.", outputPath, aspireVersion);
         await CopyTemplateTreeToDiskAsync("empty-apphost", outputPath, ApplyAllTokens, cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(templateVersion) || !string.IsNullOrEmpty(configuredChannel))
+        {
+            var config = AspireConfigFile.Load(outputPath) ?? new AspireConfigFile();
+            if (!string.IsNullOrWhiteSpace(templateVersion))
+            {
+                config.SdkVersion = templateVersion;
+            }
+            if (!string.IsNullOrEmpty(configuredChannel))
+            {
+                config.Channel = configuredChannel;
+            }
+            config.Save(outputPath);
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -354,7 +354,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonWithAppHostUsesConfiguredChannel()
+    public async Task IntegrationListCommandFormatJsonWithAppHostUsesConfiguredChannelAndKeepsImplicitPackages()
     {
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
@@ -373,7 +373,10 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var implicitCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([
+                CreatePackage("Aspire.Hosting.Redis", "1.0.0"),
+                CreatePackage("CommunityToolkit.Aspire.Hosting.NodeJS", "1.0.0")
+            ])
         };
         var dailyCache = new FakeNuGetPackageCache
         {
@@ -395,6 +398,116 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"integration list --apphost \"{appHostFile.FullName}\" --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var integrations = ReadIntegrationResults(rawJson);
+        Assert.Equal(2, integrations.Length);
+        Assert.Contains(integrations, i => i.Package == "Aspire.Hosting.Redis" && i.Version == "2.0.0");
+        Assert.Contains(integrations, i => i.Package == "CommunityToolkit.Aspire.Hosting.NodeJS" && i.Version == "1.0.0");
+    }
+
+    [Fact]
+    public async Task IntegrationListCommandFormatJsonWithAppHostReturnsEmptyWhenConfiguredChannelIsUnavailable()
+    {
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        File.WriteAllText(appHostFile.FullName, string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+            {
+              "channel": "missing"
+            }
+            """);
+
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures())
+                ])
+            };
+        });
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((_, _, _) => Task.FromResult(true)));
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"integration list --apphost \"{appHostFile.FullName}\" --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Empty(ReadIntegrationResults(rawJson));
+    }
+
+    [Fact]
+    public async Task IntegrationSearchCommandFormatJsonWithCSharpAppHostUsesConfiguredChannel()
+    {
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        File.WriteAllText(appHostFile.FullName, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <IsAspireHost>true</IsAspireHost>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+            {
+              "channel": "pr-12345"
+            }
+            """);
+
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([
+                CreatePackage("Aspire.Hosting.Redis", "1.0.0"),
+                CreatePackage("CommunityToolkit.Aspire.Hosting.NodeJS", "1.0.0")
+            ])
+        };
+        var prCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0-pr.12345.gabcdef")])
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "pr-12345")], prCache, new TestFeatures())
+                ])
+            };
+        });
+        services.AddSingleton<IAppHostProjectFactory>(new TestAppHostProjectFactory());
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"integration search redis --apphost \"{appHostFile.FullName}\" --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
@@ -403,7 +516,69 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
-        Assert.Equal("2.0.0", integration.Version);
+        Assert.Equal("2.0.0-pr.12345.gabcdef", integration.Version);
+    }
+
+    [Fact]
+    public async Task AddCommandWithCSharpAppHostUsesConfiguredChannelVersion()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        File.WriteAllText(appHostFile.FullName, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <IsAspireHost>true</IsAspireHost>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+            {
+              "channel": "pr-12345"
+            }
+            """);
+
+        var selectedPackageVersion = string.Empty;
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+        };
+        var prCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0-pr.12345.gabcdef")])
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "pr-12345")], prCache, new TestFeatures())
+                ])
+            };
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.AddPackageAsyncCallback = (_, _, packageVersion, _, _, _, _) =>
+                {
+                    selectedPackageVersion = packageVersion;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse($"add redis --apphost \"{appHostFile.FullName}\"");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Equal("2.0.0-pr.12345.gabcdef", selectedPackageVersion);
     }
 
     [Fact]
@@ -1860,7 +2035,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         };
 
         // Act
-        var result = await prompter.PromptForIntegrationVersionAsync(packages, CancellationToken.None).DefaultTimeout();
+        var result = await prompter.PromptForIntegrationVersionAsync(packages, configuredChannel: null, CancellationToken.None).DefaultTimeout();
 
         // Assert - For implicit channel with no explicit channels, should automatically select highest version without prompting
         Assert.Null(displayedChoices); // No prompt should be shown
@@ -1912,7 +2087,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         };
 
         // Act
-        await prompter.PromptForIntegrationVersionAsync(packages, CancellationToken.None).DefaultTimeout();
+        await prompter.PromptForIntegrationVersionAsync(packages, configuredChannel: null, CancellationToken.None).DefaultTimeout();
 
         // Assert - should show 2 root choices: one for implicit channel, one submenu for explicit channel
         Assert.NotNull(displayedChoices);
@@ -2251,7 +2426,7 @@ internal sealed class TestAddCommandPrompter(IInteractionService interactionServ
         };
     }
 
-    public override Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationVersionAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)
+    public override Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationVersionAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? configuredChannel, CancellationToken cancellationToken)
     {
         return PromptForIntegrationVersionCallback switch
         {

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
@@ -298,6 +298,11 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
                 Assert.True(File.Exists(appHostFile));
                 Assert.Contains(s_prVersion, await File.ReadAllTextAsync(appHostFile));
 
+                var csharpConfig = AspireConfigFile.Load(outputDirectory);
+                Assert.NotNull(csharpConfig);
+                Assert.Equal(PrChannelName, csharpConfig.Channel);
+                Assert.Equal(s_prVersion, csharpConfig.SdkVersion);
+
                 var csharpNuGetConfig = await File.ReadAllTextAsync(Path.Combine(outputDirectory, "nuget.config"));
                 Assert.Contains(packagesDirectory.FullName.Replace('\\', '/'), csharpNuGetConfig);
                 break;

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -152,7 +152,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var config = AspireConfigFile.Load(outputDirectory);
         Assert.NotNull(config);
-        Assert.Null(config.Channel);
+        Assert.Equal(PackageChannelNames.Staging, config.Channel);
+        Assert.Equal("13.4.0-preview.1.12345", config.SdkVersion);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`aspire add` and `aspire integration list/search` could not give channel-pinned AppHosts a coherent package catalog. C# AppHosts ignored `aspire.config.json#channel`, so the picker showed implicit-channel versions even when restore would install the pinned-channel package. Polyglot AppHosts did the opposite: a non-default pin narrowed discovery to that channel only, hiding integrations available from the ambient NuGet configuration.

Before this change, the same AppHost pin could produce misleading or incomplete results:

```json
{ "name": "redis", "package": "Aspire.Hosting.Redis", "version": "13.3.4" }
```

for a C# AppHost that would actually install a `pr-17105` Redis package, while a pinned polyglot AppHost could lose off-channel packages such as `CommunityToolkit.Aspire.Hosting.*`, `Aspire.Hosting.AWS`, and `Aspire.Hosting.ClickHouse`.

This updates integration discovery to read the configured channel for C# AppHosts too, include the implicit channel alongside a resolved configured channel, and prefer the configured channel for shared package IDs. If the configured channel is unavailable, discovery returns no results instead of silently falling back to implicit packages.

C# empty AppHost scaffolding now also persists the resolved channel and SDK version into `aspire.config.json`, matching the polyglot template path so later commands keep the same channel context.

### User-facing usage

A pinned AppHost can keep its channel context while still browsing integrations from the ambient NuGet configuration:

```json
{
  "channel": "pr-17105"
}
```

`aspire integration list --apphost <path> --format json` now returns the pinned-channel version for packages that exist in both channels, while keeping implicit-only integrations visible.

Generated C# empty AppHosts now include channel metadata when template resolution supplies it:

```json
{
  "sdk": {
    "version": "<resolved-sdk-version>"
  },
  "channel": "<resolved-channel>"
}
```

Fixes microsoft/aspire#17294
Fixes microsoft/aspire#17295
Fixes microsoft/aspire#17296

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
