### PR TITLE
test(ci): selective-CI probe — single Milvus component change

### DIFF
--- a/src/Components/Aspire.Milvus.Client/MilvusClientSettings.cs
+++ b/src/Components/Aspire.Milvus.Client/MilvusClientSettings.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Probe change to exercise selective CI (test-trigger-map): a no-op edit to a single
+// component so the selector picks a small subset instead of the full matrix.
+
 using System.Data.Common;
 
 namespace Aspire.Milvus.Client;


### PR DESCRIPTION
Throwaway probe to watch the select→enumerate flow on a narrow diff. The base
branch (`release/ci-trigger-test`) carries the trigger-map machinery; this PR's
diff is a one-line no-op comment in `src/Components/Aspire.Milvus.Client`.

**What to look at:** the `Tests / Setup for tests` job Summary.

**Expected (enforce mode):** a subset of 3/284 test projects —
`Aspire.Milvus.Client.Tests`, `Aspire.Hosting.Milvus.Tests`,
`Aspire.Playground.Tests` — and `enumerate-tests` builds only those.

Not a real change; do not merge.
